### PR TITLE
App descriptor changes for docker images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <java.version>1.7</java.version>
     <scs-app-maven-plugin.version>1.0.0.BUILD-SNAPSHOT</scs-app-maven-plugin.version>
     <spring.cloud.task.core.version>1.0.0.M2</spring.cloud.task.core.version>
+    <docker.tag>latest</docker.tag>
   </properties>
 
   <modules>

--- a/spring-cloud-task-app-descriptor/src/main/resources/META-INF/task-apps-docker.properties
+++ b/spring-cloud-task-app-descriptor/src/main/resources/META-INF/task-apps-docker.properties
@@ -1,4 +1,4 @@
-task.timestamp=docker:springcloudtask/timestamp-task:latest
-task.spark-client=docker:springcloudtask/spark-client-task:latest
-task.spark-cluster=docker:springcloudtask/spark-cluster-task:latest
-task.spark-yarn=docker:springcloudtask/spark-yarn-task:latest
+task.timestamp=docker:springcloudtask/timestamp-task:@docker.tag@
+task.spark-client=docker:springcloudtask/spark-client-task:@docker.tag@
+task.spark-cluster=docker:springcloudtask/spark-cluster-task:@docker.tag@
+task.spark-yarn=docker:springcloudtask/spark-yarn-task:@docker.tag@


### PR DESCRIPTION
All docker images use a new property called docker.tag that defaults to the literal
string latest which must be updated to the proper release version before a release build

Resolves #38
