### PR TITLE
Force core jackson dependencies in spark-client and cluster tasks

### DIFF
--- a/spring-cloud-task-app-generator/pom.xml
+++ b/spring-cloud-task-app-generator/pom.xml
@@ -19,6 +19,7 @@
                 <version>${scs-app-maven-plugin.version}</version>
                 <configuration>
                     <javaVersion>1.7</javaVersion>
+                    <bootVersion>1.3.5.RELEASE</bootVersion>
                     <generatedProjectHome>${session.executionRootDirectory}/apps</generatedProjectHome>
                     <generatedProjectVersion>${project.version}</generatedProjectVersion>
                     <applicationType>task</applicationType>
@@ -30,8 +31,44 @@
                     </bom>
                     <generatedApps>
                         <timestamp-task />
-                        <spark-client-task/>
-                        <spark-cluster-task/>
+                        <spark-client-task>
+                                <forceDependencies>
+                                    <dependency>
+                                        <groupId>com.fasterxml.jackson.core</groupId>
+                                        <artifactId>jackson-core</artifactId>
+                                        <version>2.4.4</version>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>com.fasterxml.jackson.core</groupId>
+                                        <artifactId>jackson-databind</artifactId>
+                                        <version>2.4.4</version>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>com.fasterxml.jackson.core</groupId>
+                                        <artifactId>jackson-annotations</artifactId>
+                                        <version>2.4.4</version>
+                                    </dependency>
+                                </forceDependencies>
+                        </spark-client-task>
+                        <spark-cluster-task>
+                            <forceDependencies>
+                                <dependency>
+                                    <groupId>com.fasterxml.jackson.core</groupId>
+                                    <artifactId>jackson-core</artifactId>
+                                    <version>2.4.4</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>com.fasterxml.jackson.core</groupId>
+                                    <artifactId>jackson-databind</artifactId>
+                                    <version>2.4.4</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>com.fasterxml.jackson.core</groupId>
+                                    <artifactId>jackson-annotations</artifactId>
+                                    <version>2.4.4</version>
+                                </dependency>
+                            </forceDependencies>
+                        </spark-cluster-task>
                         <spark-yarn-task/>
                         <sqoop-job-task/>
                         <sqoop-tool-task/>


### PR DESCRIPTION
`spring-boot-starter-parent` brings 2.6.6 core jackson dependencies (`spring-boot-starter-parent` is the parent for all the generated apps and thus it gets a higher precedence than what we defined in our starters). 
`spark-client and cluster` tasks need 2.4.4 instead
Force a dependency downgrade during the app generation by making these dependencies explicit in the generated pom.

Upgrade spring boot version to 1.3.5 in the generated apps

Resolves #34 
