### PR TITLE
Dynamically generating docker.tag property instead of hard-coding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <java.version>1.7</java.version>
     <scs-app-maven-plugin.version>1.0.0.BUILD-SNAPSHOT</scs-app-maven-plugin.version>
     <spring.cloud.task.core.version>1.0.0.M2</spring.cloud.task.core.version>
-    <docker.tag>latest</docker.tag>
   </properties>
 
   <modules>

--- a/spring-cloud-task-app-descriptor/pom.xml
+++ b/spring-cloud-task-app-descriptor/pom.xml
@@ -24,6 +24,25 @@
 
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.gmaven</groupId>
+				<artifactId>gmaven-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>execute</goal>
+						</goals>
+						<configuration>
+							<source><![CDATA[
+								pom.properties['docker.tag']=
+										"${project.version}".contains('BUILD-SNAPSHOT') ? 'latest' : "${project.version}";
+								]]></source>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<version>1.8</version>


### PR DESCRIPTION
Having `docker.tag` hardcoded to `latest` would require us to update to the proper values before a release and then reset back to `latest` after the release is done. This change would enable the setting of this flag programmatically.
