### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 == ANNOUNCEMENT: As of 1.1.0.GA / Addison.GA release, this project is now moved to link:https://github.com/spring-cloud-task-app-starters[spring-cloud-task-app-starters] organization and each of the Spring Cloud Task App Starters is now maintained in a separate repo by itself.
 
-=== This change gives us the flexibility to bug-fix, update, and release individual applications independently as opposed to a time-consuming release of all the applications at once. The link:http://docs.spring.io/spring-cloud-task-app-starters/docs/[reference guide] for all the releases are still available from the same location, though.
+=== This change gives us the flexibility to bug-fix, update, and release individual applications independently as opposed to a time-consuming release of all the applications at once. The link:https://docs.spring.io/spring-cloud-task-app-starters/docs/[reference guide] for all the releases are still available from the same location, though.
 
 === This project will not be actively tracked going forward.
 - For any application specific issues, please find the respective repo under link:https://github.com/spring-cloud-task-app-starters[spring-cloud-task-app-starters] organization and report it there. 

--- a/spring-cloud-starter-task-spark-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
+++ b/spring-cloud-starter-task-spark-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
@@ -27,7 +27,7 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 
 /*
- * NOTE: Copied from the Apache Spark (http://spark.apache.org/) source code since
+ * NOTE: Copied from the Apache Spark (https://spark.apache.org/) source code since
  * this class is not available in the Maven Central repo.
  */
 

--- a/spring-cloud-task-app-starters-docs/src/main/asciidoc/building.adoc
+++ b/spring-cloud-task-app-starters-docs/src/main/asciidoc/building.adoc
@@ -34,7 +34,7 @@ source control.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -51,13 +51,13 @@ $ ./mvnw package -DskipTests=true -P full -pl {project-artifactId} -am
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 

--- a/spring-cloud-task-app-starters-docs/src/main/asciidoc/contributing.adoc
+++ b/spring-cloud-task-app-starters-docs/src/main/asciidoc/contributing.adoc
@@ -24,7 +24,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -37,6 +37,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/spring-cloud-task-app-starters-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-task-app-starters-docs/src/main/asciidoc/overview.adoc
@@ -3,7 +3,7 @@
 
 This section goes into more detail about how you can work with Spring Cloud Task Starters as standalone applications or with Spring Cloud Data Flow.
 It assumes familiarity with general Spring Cloud Task concepts, which can be found in the Spring Cloud Task
-http://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/[reference documentation].
+https://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/[reference documentation].
 
 === Introduction
 
@@ -20,7 +20,7 @@ _Starters_ are libraries that contain the complete configuration of a Spring Clo
 Starters are not executable applications, and are intended to be included in other Spring Boot applications.
 
 _Prebuilt applications_ are Spring Boot applications that include the starters.
-Prebuilt applications are http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-first-application-executable-jar[uberjars] and include minimal code required to execute standalone.
+Prebuilt applications are https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-first-application-executable-jar[uberjars] and include minimal code required to execute standalone.
 
 [NOTE]
 Only starters are present in the source code of the project.
@@ -110,7 +110,7 @@ You have the following options:
 ===== Using generic Spring Cloud Task applications
 
 If you want to add your own custom applications to your solution, you can simply create a new Spring Cloud Task project and run it the same way as the applications provided by Spring Cloud Task Application Starters, independently or via Spring Cloud Data Flow.
-The process is described in the http://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/#getting-started#_getting_started[Getting Started Guide] of Spring Cloud Task.
+The process is described in the https://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/#getting-started#_getting_started[Getting Started Guide] of Spring Cloud Task.
 
 ===== Using the starters to create custom components
 

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-cloud-task-app-starters/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-task-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-task/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://spark.apache.org/ with 1 occurrences migrated to:  
  https://spark.apache.org/ ([https](https://spark.apache.org/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences