### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/settings.xml
+++ b/settings.xml
@@ -7,7 +7,7 @@
   ~  * you may not use this file except in compliance with the License.
   ~  * You may obtain a copy of the License at
   ~  *
-  ~  *      http://www.apache.org/licenses/LICENSE-2.0
+  ~  *      https://www.apache.org/licenses/LICENSE-2.0
   ~  *
   ~  * Unless required by applicable law or agreed to in writing, software
   ~  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-client/src/main/java/org/springframework/cloud/task/app/spark/client/SparkClientTaskConfiguration.java
+++ b/spring-cloud-starter-task-spark-client/src/main/java/org/springframework/cloud/task/app/spark/client/SparkClientTaskConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
+++ b/spring-cloud-starter-task-spark-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *    https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-client/src/test/java/org/springframework/cloud/task/app/spark/client/SparkClientRunnerTests.java
+++ b/spring-cloud-starter-task-spark-client/src/test/java/org/springframework/cloud/task/app/spark/client/SparkClientRunnerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-cluster/src/main/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterTaskConfiguration.java
+++ b/spring-cloud-starter-task-spark-cluster/src/main/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterTaskConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-cluster/src/main/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterTaskProperties.java
+++ b/spring-cloud-starter-task-spark-cluster/src/main/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-cluster/src/test/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterTaskPropertiesTests.java
+++ b/spring-cloud-starter-task-spark-cluster/src/test/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-yarn/src/main/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnTaskConfiguration.java
+++ b/spring-cloud-starter-task-spark-yarn/src/main/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnTaskConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-yarn/src/main/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnTaskProperties.java
+++ b/spring-cloud-starter-task-spark-yarn/src/main/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-spark-yarn/src/test/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnTaskPropertiesTests.java
+++ b/spring-cloud-starter-task-spark-yarn/src/test/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-job/src/main/java/org/springframework/cloud/task/app/sqoop/job/SqoopJobTaskConfiguration.java
+++ b/spring-cloud-starter-task-sqoop-job/src/main/java/org/springframework/cloud/task/app/sqoop/job/SqoopJobTaskConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-job/src/main/java/org/springframework/cloud/task/app/sqoop/job/SqoopJobTaskProperties.java
+++ b/spring-cloud-starter-task-sqoop-job/src/main/java/org/springframework/cloud/task/app/sqoop/job/SqoopJobTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-job/src/test/java/org/springframework/cloud/task/app/sqoop/job/SqoopToolJobApplicationTests.java
+++ b/spring-cloud-starter-task-sqoop-job/src/test/java/org/springframework/cloud/task/app/sqoop/job/SqoopToolJobApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-job/src/test/java/org/springframework/cloud/task/app/sqoop/job/SqoopToolJobPropertiesTests.java
+++ b/spring-cloud-starter-task-sqoop-job/src/test/java/org/springframework/cloud/task/app/sqoop/job/SqoopToolJobPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-tool/src/main/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskConfiguration.java
+++ b/spring-cloud-starter-task-sqoop-tool/src/main/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-tool/src/main/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskProperties.java
+++ b/spring-cloud-starter-task-sqoop-tool/src/main/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-tool/src/test/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskApplicationTests.java
+++ b/spring-cloud-starter-task-sqoop-tool/src/test/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-sqoop-tool/src/test/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskPropertiesTests.java
+++ b/spring-cloud-starter-task-sqoop-tool/src/test/java/org/springframework/cloud/task/app/sqoop/tool/SqoopToolTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-timestamp/src/main/java/org/springframework/cloud/task/app/timestamp/TimestampTaskConfiguration.java
+++ b/spring-cloud-starter-task-timestamp/src/main/java/org/springframework/cloud/task/app/timestamp/TimestampTaskConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-timestamp/src/main/java/org/springframework/cloud/task/app/timestamp/TimestampTaskProperties.java
+++ b/spring-cloud-starter-task-timestamp/src/main/java/org/springframework/cloud/task/app/timestamp/TimestampTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-timestamp/src/test/java/org/springframework/cloud/task/app/timestamp/TimestampTaskPropertiesTests.java
+++ b/spring-cloud-starter-task-timestamp/src/test/java/org/springframework/cloud/task/app/timestamp/TimestampTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-timestamp/src/test/java/org/springframework/cloud/task/app/timestamp/TimestampTaskTests.java
+++ b/spring-cloud-starter-task-timestamp/src/test/java/org/springframework/cloud/task/app/timestamp/TimestampTaskTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-task-timestamp/src/test/resources/application.properties
+++ b/spring-cloud-starter-task-timestamp/src/test/resources/application.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html-multipage.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html-singlepage.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-task-app-starters-docs/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-task-spark-common/src/main/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskProperties.java
+++ b/spring-cloud-task-spark-common/src/main/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-task-spark-common/src/test/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskPropertiesTests.java
+++ b/spring-cloud-task-spark-common/src/test/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-task-sqoop-common/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonRunnerUtils.java
+++ b/spring-cloud-task-sqoop-common/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonRunnerUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-task-sqoop-common/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskProperties.java
+++ b/spring-cloud-task-sqoop-common/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-task-sqoop-common/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskPropertiesTests.java
+++ b/spring-cloud-task-sqoop-common/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-task-sqoop-common/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopToolDatabaseConfiguration.java
+++ b/spring-cloud-task-sqoop-common/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopToolDatabaseConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 36 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).